### PR TITLE
docs: document multi-glob routes for v1.10.0

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -359,12 +359,14 @@ $ curl http://localhost:2830/geo/ma/boston/02125
 ::: tip 🆕 Available in v1.10.0
 :::
 
-A single route may contain more than one glob, as long as adjacent globs can be unambiguously partitioned. Two globs in the same route must be separated by either:
+A single route may contain more than one glob. Two globs in the same route must be separated by either:
 
-- a static or regex segment, which constrains the path text and so bounds where the earlier glob can grow, or
+- a static or regex segment, or
 - a capture limit on the earlier glob, which bounds how many segments it can consume.
 
-Placeholder segments (`{name}`) do **not** count as separators because they accept any one segment of any content, which would leave the split between the surrounding globs ambiguous.
+Static segments pin the path text exactly. Regex segments are accepted as separators regardless of how broadly the regex matches — a tight pattern like `/[0-9]+/` gives a real disambiguation point, while a permissive pattern like `/.+/` does not, but the regex is taken as your explicit opt-in to that route shape and the resulting bindings follow the normal [matching priority](#matching-priority).
+
+Placeholder segments (`{name}`) do **not** count as separators because they accept any one segment of any content with no opt-in, which would leave the split between the surrounding globs silently ambiguous.
 
 Below are valid multi-glob routes:
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -354,6 +354,50 @@ $ curl http://localhost:2830/geo/ma/boston/02125
 ```
 :::
 
+#### Multiple globs per route
+
+::: tip 🆕 Available in v1.10.0
+:::
+
+A single route may contain more than one glob, as long as adjacent globs can be unambiguously partitioned. Two globs in the same route must be separated by either:
+
+- a static or regex segment, which constrains the path text and so bounds where the earlier glob can grow, or
+- a capture limit on the earlier glob, which bounds how many segments it can consume.
+
+Placeholder segments (`{name}`) do **not** count as separators because they accept any one segment of any content, which would leave the split between the surrounding globs ambiguous.
+
+Below are valid multi-glob routes:
+
+```go
+// Static separator between unbounded globs.
+f.Get("/files/{prefix: **}/blob/{path: **}", ...)
+
+// Regex separator between unbounded globs.
+f.Get("/repos/{owner: **}/{id: /[0-9]+/}/{path: **}", ...)
+
+// Capture limit on the earlier glob.
+f.Get("/archive/{head: **, capture: 2}/{tail: **}", ...)
+
+// Three globs with mixed separators.
+f.Get("/api/{a: **, capture: 2}/sep/{b: **, capture: 2}/end/{c: **}", ...)
+```
+
+These routes are rejected at registration:
+
+```go
+// Two unbounded globs with no separator.
+f.Get("/api/{a: **}/{b: **}", ...)
+
+// Placeholder is not an anchor — the split is ambiguous.
+f.Get("/api/{a: **}/{id}/{b: **}", ...)
+
+// A capture limit on the *later* glob does not help, since the earlier
+// (unbounded) glob is what consumes path segments first.
+f.Get("/api/{a: **}/{b: **, capture: 2}", ...)
+```
+
+For a non-final bounded glob, matching grows the captured segment up to the capture limit and prefers the longest partition that lets the rest of the route match. If a partition matches through a more-specific sibling (static, regex, or placeholder), that match wins immediately even when a longer partition would also succeed through a glob sibling. In other words, the documented [matching priority](#matching-priority) outranks partition length.
+
 ## Combo routes
 
 The `Combo` method can create combo routes when you have different handlers for different HTTP methods of the same route:


### PR DESCRIPTION
### Describe the pull request

Documents the multiple-match-all-globs-per-route capability landing in flamego/flamego#195 and slated for v1.10.0. Adds a new "Multiple globs per route" subsection under the existing "Globs" section in `docs/routing.md`, covering:

- Valid multi-glob route shapes (static/regex separators, capture limits) with examples.
- Routes that are rejected at registration, including why placeholders cannot serve as anchors.
- That regex segments are accepted as separators regardless of how broadly the regex matches — broad patterns like `/.+/` are taken as the author's explicit opt-in to that route shape, and resulting bindings follow the normal matching priority.
- Greedy-within-cap matching semantics for non-final bounded globs, and that match style priority outranks partition length.

Pairs with flamego/flamego.cn#3 for the Chinese translation.

Link to the issue: n/a

### Checklist

- [x] I agree to follow this project's [Code of Conduct](https://golang.org/conduct) by submitting this pull request.
- [x] I totally understand sending a pull request has no guarantee to be merged, and the review rounds may take a long time.